### PR TITLE
Updating glue-vispy-viewers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True # [py<37]
+  skip: True  # [py<37 or ppc64le or s390x]
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.12.2" %}
+{% set version = "1.0.5" %}
 
 package:
   name: glue-vispy-viewers
@@ -7,11 +7,11 @@ package:
 source:
   fn: glue-vispy-viewers-{{version}}.tar.gz
   url: https://pypi.io/packages/source/g/glue-vispy-viewers/glue-vispy-viewers-{{version}}.tar.gz
-  sha256: 3bc00472624e53c2d5ecb50d7bce29acdb2e6f6459694188044daa62c76ae8cf
+  sha256: 9d126735b1c1b08a56e02e11d0eba20c040ff934c8d1fd6644e7ee085a420569
 
 build:
-  noarch: python
   number: 0
+  skip: True # [py<37]
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
@@ -23,14 +23,16 @@ requirements:
 
   run:
     - python
-    - numpy >=1.9
+    - numpy >=1.17
     - pyopengl
-    - glue-core >=0.14
-    - matplotlib
+    - glue-core >=1.0
+    - matplotlib-base
     - qtpy
     - scipy
-    - astropy >=1.1
-    - pyqt >=5.6,<6.0a0
+    - astropy >=4.0
+    - pillow
+    - vispy >=0.6
+    - pyqt >=5.9,<6.0a0
 
 test:
   imports:
@@ -40,7 +42,7 @@ test:
 
 about:
   home:  http://glueviz.org
-  license: BSD 3-Clause
+  license: BSD-3-Clause
   summary: 3D viewers for Glue
   dev_url: https://github.com/glue-viz/glue-vispy-viewers
   doc_url: http://glueviz.org/en/stable/gui_guide/3d_viewers.html

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
 
   run:
     - python
-    - numpy >=1.17
+    - numpy
     - pyopengl
     - glue-core >=1.0
     - matplotlib-base
@@ -47,7 +47,7 @@ test:
 
 about:
   home:  https://glueviz.org
-  license: BSD-3-Clause
+  license: BSD-2-Clause
   license_family: BSD
   license_file: LICENSE
   summary: 3D viewers for Glue

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37 or ppc64le or s390x]
+  # Skipping unnecessary linux platforms that don't need viz.
+  skip: True  # [py<36 or ppc64le or s390x]
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - python
     - setuptools
     - setuptools_scm
+    - wheel
 
   run:
     - python
@@ -39,14 +40,25 @@ test:
     - glue_vispy_viewers
     - glue_vispy_viewers.scatter
     - glue_vispy_viewers.volume
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
-  home:  http://glueviz.org
+  home:  https://glueviz.org
   license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
   summary: 3D viewers for Glue
+  description: 3D viewers for Glue using VisPy
   dev_url: https://github.com/glue-viz/glue-vispy-viewers
-  doc_url: http://glueviz.org/en/stable/gui_guide/3d_viewers.html
+  doc_url: https://glueviz.org/en/stable/gui_guide/3d_viewers.html
 
 extra:
   recipe-maintainers:
     - astrofrog-conda-forge
+  skip-lints:
+    - missing_doc_source_url
+    - missing_license_url
+    - gui_app


### PR DESCRIPTION
Updating from 0.12.2 to 1.0.5:
- Updating version, hash
- Updated dependencies

# Package Info
Source: https://github.com/glue-viz/glue-vispy-viewers/tree/v1.0.5
Diff: https://github.com/glue-viz/glue-vispy-viewers/compare/v0.12.2...v1.0.5